### PR TITLE
fix error [Cannot find module 'XXX']

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "src",
     "outDir": "./built",
     "allowJs": true,
     "noImplicitAny": true,
@@ -8,6 +9,7 @@
     "module": "commonjs"
   },
   "include": [
+    "./tests/**/*",
     "./src/**/*"
   ],
   "exclude": [


### PR DESCRIPTION
On Windows, VS Code shows error messages in PROBLEMS pane:
Cannot find module 'api/models'.
Cannot find module 'api/utils/Utils'.